### PR TITLE
Prevent invalid inputs from returning `true`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - 5.5
   - 5.6
   - hhvm
+    dist: trusty
 
 before_script:
   - wget http://getcomposer.org/composer.phar
@@ -26,4 +27,3 @@ matrix:
   allow_failures:
     - php: 5.6
     - php: hhvm
-    dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
 language: php
-dist: precise
+dist: trusty
 php:
-  - 5.3
-  - 5.4
-  - 5.5
+  - '5.4'
+  - '5.6'
+  - '7.0'
+  - hhvm # on Trusty only
+  - nightly
 
 before_script:
-  - wget http://getcomposer.org/composer.phar
-  - php composer.phar install --dev
+  - curl -sSfL -o ~/.phpenv/versions/hhvm/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar
+  - composer install
 
 script:
   - cd ./tests/
@@ -18,13 +20,3 @@ after_script:
 
 notifications:
   email: false
-
-matrix:
-  fast_finish: true
-  include:
-    - php: 5.6
-    - php: hhvm
-      dist: trusty
-  allow_failures:
-    - php: 5.6
-    - php: hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-dist: trusty
+dist: precise
 php:
   - 5.3
   - 5.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ php:
   - 5.3
   - 5.4
   - 5.5
-  - 5.6
-  - hhvm
 
 before_script:
   - wget http://getcomposer.org/composer.phar

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,4 @@ matrix:
   allow_failures:
     - php: 5.6
     - php: hhvm
+    dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ php:
   - 5.5
   - 5.6
   - hhvm
-    dist: trusty
 
 before_script:
   - wget http://getcomposer.org/composer.phar
@@ -24,6 +23,10 @@ notifications:
 
 matrix:
   fast_finish: true
+  include:
+    - php: 5.6
+    - php: hhvm
+      dist: trusty
   allow_failures:
     - php: 5.6
     - php: hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: php
+dist: trusty
 php:
   - 5.3
   - 5.4

--- a/CIDRmatch/CIDRmatch.php
+++ b/CIDRmatch/CIDRmatch.php
@@ -70,6 +70,9 @@ class CIDRmatch
     // inspired by: http://stackoverflow.com/questions/7951061/matching-ipv6-address-to-a-cidr-subnet
     private function IPv6Match($address, $subnetAddress, $subnetMask)
     {
+        if (!filter_var($subnetAddress, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) || $subnetMask === NULL || $subnetMask === "" || $subnetMask < 0 || $subnetMask > 128) {
+            return false;
+        }
         $subnet = inet_pton($subnetAddress);
         $addr = inet_pton($address);
 
@@ -81,6 +84,9 @@ class CIDRmatch
     // inspired by: http://stackoverflow.com/questions/594112/matching-an-ip-to-a-cidr-mask-in-php5
     private function IPv4Match($address, $subnetAddress, $subnetMask)
     {
+        if (!filter_var($subnetAddress, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) || $subnetMask === NULL || $subnetMask === "" || $subnetMask < 0 || $subnetMask > 32) {
+            return false;
+        }
         if ((ip2long($address) & ~((1 << (32 - $subnetMask)) - 1)) == ip2long($subnetAddress)) {
             return true;
         }

--- a/CIDRmatch/CIDRmatch.php
+++ b/CIDRmatch/CIDRmatch.php
@@ -19,8 +19,11 @@ class CIDRmatch
     public function match($ip, $cidr)
     {
         $c = explode('/', $cidr);
-				$subnet = isset($c[0]) ? $c[0] : NULL;
-				$mask   = isset($c[1]) ? $c[1] : NULL;
+        $subnet = isset($c[0]) ? $c[0] : NULL;
+        $mask   = isset($c[1]) ? $c[1] : NULL;
+        if ($mask === null) {
+            $mask = 32;
+        }
 
         if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
             // it's valid
@@ -89,11 +92,12 @@ class CIDRmatch
         if (!filter_var($subnetAddress, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) || $subnetMask === NULL || $subnetMask === "" || $subnetMask < 0 || $subnetMask > 32) {
             return false;
         }
-        if ((ip2long($address) & ~((1 << (32 - $subnetMask)) - 1)) == ip2long($subnetAddress)) {
-            return true;
-        }
 
-        return false;
+        $address = ip2long($address);
+        $subnetAddress = ip2long($subnetAddress);
+        $mask = -1 << (32 - $subnetMask);
+        $subnetAddress &= $mask; # nb: in case the supplied subnet wasn't correctly aligned
+        return ($address & $mask) == $subnetAddress;
     }
 
 }

--- a/CIDRmatch/CIDRmatch.php
+++ b/CIDRmatch/CIDRmatch.php
@@ -18,7 +18,9 @@ class CIDRmatch
 
     public function match($ip, $cidr)
     {
-        list($subnet, $mask) = explode('/', $cidr);
+        $c = explode('/', $cidr);
+				$subnet = isset($c[0]) ? $c[0] : NULL;
+				$mask   = isset($c[1]) ? $c[1] : NULL;
 
         if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
             // it's valid

--- a/tests/CIDRmatchTest/CIDRmatchTest.php
+++ b/tests/CIDRmatchTest/CIDRmatchTest.php
@@ -11,7 +11,7 @@ require_once("CIDRmatch/CIDRmatch.php");
 class CIDRmatchTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * Ensure that IPv4 addresses work
+     * Ensure that IPv4 addresses match
      */
     public function testIPv4Match()
     {
@@ -22,13 +22,39 @@ class CIDRmatchTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * Ensure that IPv6 addresses work
+     * Ensure that IPv4 addresses don't match with invalid input
+     */
+    public function testIPv4NoMatch()
+    {
+        $cidrMatch = new CIDRmatch();
+        $this->assertFalse($cidrMatch->match('Not an IP address', '104.132.0.0/14'));
+        $this->assertFalse($cidrMatch->match('104.132.31.99', 'Not an IP address/14'));
+        $this->assertFalse($cidrMatch->match('104.132.31.99', '104.132.0.0/33'));
+        $this->assertFalse($cidrMatch->match('104.132.31.99', '104.132.0.0/'));
+        $this->assertFalse($cidrMatch->match('104.132.31.99', '104.132.0.0'));
+    }
+
+    /**
+     * Ensure that IPv6 addresses match
      */
     public function testIPv6Match()
     {
         $cidrMatch = new CIDRmatch();
         $this->assertTrue($cidrMatch->match('2001:0db8:85a3:08d3:1319:8a2e:0370:7347', '2001:0db8:85a3:08d3::/64'));
         $this->assertTrue($cidrMatch->match('2a00:1450:400c:c04::6a', '2a00:1450::/32'));
+    }
+
+    /**
+     * Ensure that IPv6 addresses don't match with invalid input
+     */
+    public function testIPv6NoMatch()
+    {
+        $cidrMatch = new CIDRmatch();
+        $this->assertFalse($cidrMatch->match('Not an IP address', '2001:0db8:85a3:08d3::/64'));
+        $this->assertFalse($cidrMatch->match('2001:0db8:85a3:08d3:1319:8a2e:0370:7347', 'Not an IP address/64'));
+        $this->assertFalse($cidrMatch->match('2001:0db8:85a3:08d3:1319:8a2e:0370:7347', '2001:0db8:85a3:08d3::/129'));
+        $this->assertFalse($cidrMatch->match('2001:0db8:85a3:08d3:1319:8a2e:0370:7347', '2001:0db8:85a3:08d3::/'));
+        $this->assertFalse($cidrMatch->match('2001:0db8:85a3:08d3:1319:8a2e:0370:7347', '2001:0db8:85a3:08d3::'));
     }
 
 

--- a/tests/CIDRmatchTest/CIDRmatchTest.php
+++ b/tests/CIDRmatchTest/CIDRmatchTest.php
@@ -1,13 +1,14 @@
 <?php
 
 use CIDRmatch\CIDRmatch;
+require_once("CIDRmatch/CIDRmatch.php");
 
 /**
  * A suite of tests for the CIDRmatch class
  *
  * @author Thomas Lutz
  */
-class CIDRmatchTest extends PHPUnit_Framework_TestCase
+class CIDRmatchTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Ensure that IPv4 addresses work

--- a/tests/CIDRmatchTest/CIDRmatchTest.php
+++ b/tests/CIDRmatchTest/CIDRmatchTest.php
@@ -1,14 +1,13 @@
 <?php
 
 use CIDRmatch\CIDRmatch;
-require_once("CIDRmatch/CIDRmatch.php");
 
 /**
  * A suite of tests for the CIDRmatch class
  *
  * @author Thomas Lutz
  */
-class CIDRmatchTest extends \PHPUnit\Framework\TestCase
+class CIDRmatchTest extends PHPUnit_Framework_TestCase
 {
     /**
      * Ensure that IPv4 addresses match

--- a/tests/CIDRmatchTest/CIDRmatchTest.php
+++ b/tests/CIDRmatchTest/CIDRmatchTest.php
@@ -56,5 +56,39 @@ class CIDRmatchTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($cidrMatch->match('2001:0db8:85a3:08d3:1319:8a2e:0370:7347', '2001:0db8:85a3:08d3::'));
     }
 
+    /**
+     * Ensure that case from issue #2 (https://github.com/tholu/php-cidr-match/issues/2) works
+     */
+    public function testIssue2() {
+        $cidrMatch = new CIDRmatch();
+
+        $addr = '192.168.1.1';
+        $this->assertTrue($cidrMatch->match($addr, '192.168.1.0/24'));
+        $this->assertFalse($cidrMatch->match($addr, '1.2.3.4/1'));
+        $this->assertFalse($cidrMatch->match($addr, '192.168.1.1/33')); // invalid subnet
+        $this->assertTrue($cidrMatch->match($addr,  '0.0.0.0/0'));
+        $this->assertFalse($cidrMatch->match($addr, '256.256.256/0')); // invalid CIDR notation
+
+        $addr = '10.5.5.1';
+        $this->assertTrue($cidrMatch->match($addr, '10.0.0.1/8'));
+        $this->assertTrue($cidrMatch->match($addr, '10.0.0.10/8'));
+        $this->assertTrue($cidrMatch->match($addr, '10.5.5.0/16'));
+        $this->assertFalse($cidrMatch->match($addr, '10.4.5.0/16'));
+        $this->assertTrue($cidrMatch->match($addr, '10.4.5.0/15'));
+
+        $this->assertTrue($cidrMatch->match('2a01:198:603:0:396e:4789:8e99:890f', '2a01:198:603:0::/65'));
+        $this->assertFalse($cidrMatch->match('2a00:198:603:0:396e:4789:8e99:890f', '2a01:198:603:0::/65'));
+        $this->assertFalse($cidrMatch->match('2a01:198:603:0:396e:4789:8e99:890f', '::1'));
+        $this->assertFalse($cidrMatch->match('0:0:603:0:396e:4789:8e99:0001', '::1'));
+        $this->assertFalse($cidrMatch->match('}__test|O:21:&quot;JDatabaseDriverMysqli&quot;:3:{s:2', '::1'));   
+    }
+
+    /**
+     * Ensure that case from issue #3 (https://github.com/tholu/php-cidr-match/issues/3) works
+     */
+    public function testIssue3() {
+        $cidrMatch = new CIDRmatch();
+        $this->assertFalse($cidrMatch->match('91.124.36.116', '2a02:6b8:0:1a00::/56'));
+    }
 
 }


### PR DESCRIPTION
Also fixes Travis Build to use Ubuntu Trusty and recent PHP versions. Resolves #2, #3, #4.