### PR TITLE
Fix IPv6 Mask Size

### DIFF
--- a/CIDRmatch/CIDRmatch.php
+++ b/CIDRmatch/CIDRmatch.php
@@ -21,9 +21,6 @@ class CIDRmatch
         $c = explode('/', $cidr);
         $subnet = isset($c[0]) ? $c[0] : NULL;
         $mask   = isset($c[1]) ? $c[1] : NULL;
-        if ($mask === null) {
-            $mask = 32;
-        }
 
         if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
             // it's valid
@@ -41,9 +38,17 @@ class CIDRmatch
 
         switch ($ipVersion) {
             case 'v4':
+                if ($mask === null) {
+                    $mask = 32;
+                }
+
                 return $this->IPv4Match($ip, $subnet, $mask);
                 break;
             case 'v6':
+                if ($mask === null) {
+                    $mask = 128;
+                }
+
                 return $this->IPv6Match($ip, $subnet, $mask);
                 break;
         }

--- a/tests/CIDRmatchTest/CIDRmatchTest.php
+++ b/tests/CIDRmatchTest/CIDRmatchTest.php
@@ -41,6 +41,7 @@ class CIDRmatchTest extends PHPUnit_Framework_TestCase
         $cidrMatch = new CIDRmatch();
         $this->assertTrue($cidrMatch->match('2001:0db8:85a3:08d3:1319:8a2e:0370:7347', '2001:0db8:85a3:08d3::/64'));
         $this->assertTrue($cidrMatch->match('2a00:1450:400c:c04::6a', '2a00:1450::/32'));
+        $this->assertTrue($cidrMatch->match('2001:0db8:85a3:08d3:1319:8a2e:0370:7347', '2001:0db8:85a3:08d3:1319:8a2e:0370:7347'));
     }
 
     /**


### PR DESCRIPTION
The code has a default mask size of 32 for IPv4 _and_ IPv6. 32 is only correct for IPv4

I believe this fixes #6

I know the advice is not to use this library, but I'm still using it at the moment and getting this fixed would be ideal