### PR TITLE
Avoid deprecated float to int conversion.

### DIFF
--- a/CIDRmatch/CIDRmatch.php
+++ b/CIDRmatch/CIDRmatch.php
@@ -57,7 +57,7 @@ class CIDRmatch
     // inspired by: http://stackoverflow.com/questions/7951061/matching-ipv6-address-to-a-cidr-subnet
     private function IPv6MaskToByteArray($subnetMask)
     {
-        $addr = str_repeat("f", $subnetMask / 4);
+        $addr = str_repeat("f", intdiv($subnetMask, 4));
         switch ($subnetMask % 4) {
             case 0:
                 break;


### PR DESCRIPTION
I tried to use CIDRmatch.php and noted that PHP returns the following warning:

Deprecated: Implicit conversion from float 7.25 to int loses precision in on line 60.

This happens in the first line of function IPv6MaskToByteArray($subnetMask)
```$addr = str_repeat("f", $subnetMask / 4);```
if $subnetMask is for example 29.

This patch used intdiv() to avoid the float to int conversion and does a integer division.